### PR TITLE
Use pull_request for formatting workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, edited]
   discussion:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened, closed, synchronize, review_requested]
 
 permissions:


### PR DESCRIPTION
## Summary

Use the standard `pull_request` event for the formatting workflow instead of `pull_request_target`.

External fork formatting remains handled by the Ultralytics GitHub App without exposing base-repository secrets to fork code.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🔧 Updates the formatting workflow to use the standard `pull_request` event instead of `pull_request_target`.

### 📊 Key Changes

- Replaces the `pull_request_target` trigger with `pull_request`.
- Keeps the workflow running for opened, closed, synchronized, and review-requested pull requests.
- Applies the change in `.github/workflows/format.yml`.

### 🎯 Purpose & Impact

- 🔒 Improves workflow security by running formatting checks against the pull request code rather than the target branch context.
- ✅ Helps reduce the risk of untrusted pull request code accessing repository-level privileges or secrets.
- ⚙️ Formatting checks may behave differently for pull requests from forks because `pull_request` workflows have more restricted access to secrets and write permissions.