### PR TITLE
Accept normalized CLA signature comments

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   CLA:
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I sign the CLA'))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I sign the CLA')))
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Valid CLA signature comments with trailing whitespace or surrounding Markdown currently never reach the normalized action matcher because the workflow gate requires exact equality.

This makes only the signature gate permissive. The `recheck` command remains exact, and the action still decides whether a single normalized line is a valid signature, so quoted or instructional text does not sign the CLA.

Related matcher fix: ultralytics/actions#894

Validation:
- `actionlint .github/workflows/cla.yml`
- `npx prettier@3.8.5 --check .github/workflows/cla.yml`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the CLA workflow to pass comments containing the normalized CLA signature text to the matcher instead of requiring an exact comment-body match.

### 📊 Key Changes

- Changed the CLA signature condition in `.github/workflows/cla.yml` from exact equality to `contains(...)`.
- Kept the `recheck` command condition as an exact match.
- Left signature validation to the existing action matcher, which determines whether the normalized content is a valid signature.

### 🎯 Purpose & Impact

- CLA signature comments with surrounding Markdown or trailing whitespace can now reach the signature matcher.
- Quoted or instructional text is not automatically treated as a signature because the action matcher still performs the final validation.
- The workflow file was validated with `actionlint` and Prettier.